### PR TITLE
Add support for the language encoding flag

### DIFF
--- a/lib/IO/Compress/Zip.pm
+++ b/lib/IO/Compress/Zip.pm
@@ -325,8 +325,8 @@ sub mkHeader
     $gpFlag |= ZIP_GP_FLAG_LZMA_EOS_PRESENT
         if $method == ZIP_CM_LZMA ;
 
-#    $gpFlag |= ZIP_GP_FLAG_LANGUAGE_ENCODING
-#        if  $param->getValue('utf8') && (length($filename) || length($comment));
+    $gpFlag |= ZIP_GP_FLAG_LANGUAGE_ENCODING
+        if  $param->getValue('utf8') && (length($filename) || length($comment));
 
     my $version = $ZIP_CM_MIN_VERSIONS{$method};
     $version = ZIP64_MIN_VERSION
@@ -682,7 +682,7 @@ our %PARAMS = (
             'name'      => [IO::Compress::Base::Common::Parse_any,       ''],
             'filtername'=> [IO::Compress::Base::Common::Parse_code,      undef],
             'canonicalname'=> [IO::Compress::Base::Common::Parse_boolean,   0],
-#            'utf8'      => [IO::Compress::Base::Common::Parse_boolean,   0],
+            'utf8'      => [IO::Compress::Base::Common::Parse_boolean,   0],
             'time'      => [IO::Compress::Base::Common::Parse_any,       undef],
             'extime'    => [IO::Compress::Base::Common::Parse_any,       undef],
             'exunix2'   => [IO::Compress::Base::Common::Parse_any,       undef], 
@@ -1342,6 +1342,13 @@ filenames before they are stored in C<$zipfile>.
         zip [ <$dir/*.txt> ] => $zipfile,
             FilterName => sub { s[^$dir/][] } ;
     }
+
+=item C<< Utf8 => 0|1 >>
+
+This option allows to control the language encoding (EFS) flag. If set, the
+filename and comment fields for the file must be encoded using UTF-8.
+
+This option defaults to B<false>.
 
 =item C<< Time => $number >>
 

--- a/lib/IO/Uncompress/Unzip.pm
+++ b/lib/IO/Uncompress/Unzip.pm
@@ -554,6 +554,7 @@ sub _readZipHeader($)
     my $extraField;
     my @EXTRA = ();
     my $streamingMode = ($gpFlag & ZIP_GP_FLAG_STREAMING_MASK) ? 1 : 0 ;
+    my $utf8 = ($gpFlag & ZIP_GP_FLAG_LANGUAGE_ENCODING) ? 1 : 0;
 
     return $self->HeaderError("Encrypted content not supported")
         if $gpFlag & (ZIP_GP_FLAG_ENCRYPTED_MASK|ZIP_GP_FLAG_STRONG_ENCRYPTED_MASK);
@@ -708,6 +709,7 @@ sub _readZipHeader($)
         'UncompressedLength' => $uncompressedLength ,
         'CRC32'              => $crc32 ,
         'Name'               => $filename,
+        'Utf8'               => $utf8,
         'Time'               => _dosToUnixTime($lastModTime),
         'Stream'             => $streamingMode,
 

--- a/t/112utf8-zip.t
+++ b/t/112utf8-zip.t
@@ -1,0 +1,60 @@
+BEGIN {
+    if ($ENV{PERL_CORE}) {
+        chdir 't' if -d 't';
+        @INC = ("../lib", "lib/compress");
+    }
+}
+
+use lib qw(t t/compress);
+use strict;
+use warnings;
+use bytes;
+
+use Test::More ;
+use CompTestUtils;
+
+use IO::Compress::Zip     qw($ZipError);
+use IO::Uncompress::Unzip qw($UnzipError);
+
+BEGIN {
+    # use Test::NoWarnings, if available
+    my $extra = 0 ;
+    $extra = 1
+        if eval { require Test::NoWarnings ;  import Test::NoWarnings; 1 };
+
+    plan tests => 7 + $extra;
+}
+
+{
+    title "Create a simple zip - language encoding flag set";
+
+    my $lex = new LexFile my $file1;
+
+    my $zip = new IO::Compress::Zip $file1,
+                    Name => "one", Utf8 => 1;
+
+    my $content = 'Hello, world!';
+    is $zip->write($content), length($content), "write";
+    $zip->newStream(Name=> "two", Utf8 => 1);
+    is $zip->write($content), length($content), "write";
+    $zip->newStream(Name=> "three", Utf8 => 0);
+    is $zip->write($content), length($content), "write";
+    $zip->newStream(Name=> "four");
+    is $zip->write($content), length($content), "write";
+    ok $zip->close(), "closed";
+
+    my $u = new IO::Uncompress::Unzip $file1
+        or die "Cannot open $file1: $UnzipError";
+
+    my $status;
+    my @utf8;
+    for ($status = 1; $status > 0; $status = $u->nextStream())
+    {
+        push @utf8, $u->getHeaderInfo()->{Utf8};
+    }
+
+    die "Error processing $file1: $status $!\n"
+        if $status < 0;
+
+    is_deeply \@utf8, [1, 1, 0, 0], "language encoding flag set";
+}


### PR DESCRIPTION
I recently noticed that `IO::Compress::Zip` does currently not support setting the language encoding flag of a zip file member, which can result in file names with 'weird' characters when unpacking a zip file where the member names are UTF-8 encoded (for example with the Windows Explorer on Windows 7, but likely also with other tools).

This pull request adds support for setting the flag when creating a zip file, and to get back the value of the flag when reading a zip file. It doesn't do any encoding or decoding of the name and comment fields.

This is also a very partial revert of 02889ffc where the support for the language encoding flag was commented out in `IO::Compress::Zip`. Unfortunately, I couldn't find a reason why this was done.

I've already prepared [a branch in `Archive-Zip-SimpleZip`](/mstock/Archive-Zip-SimpleZip/tree/feature/language-encoding-flag) based on this, so should this get merged, I'm planning to create a pull request for `Archive-Zip-SimpleZip` as well.