### PR TITLE
Fix typos in POD

### DIFF
--- a/bin/streamzip
+++ b/bin/streamzip
@@ -111,7 +111,7 @@ streamzip - create a zip file from stdin
 
 =head1 SYNOPSIS
 
-    producer | streamzip [opts] | comsumer
+    producer | streamzip [opts] | consumer
     producer | streamzip [opts] -zipfile=output.zip
 
 =head1 DESCRIPTION

--- a/lib/IO/Compress/Zip.pm
+++ b/lib/IO/Compress/Zip.pm
@@ -1356,7 +1356,7 @@ You should only need to use this option if you want the I<archive member name>
 to be different from the uncompressed filename or when the input is a filehandle or a buffer.
 
 The default behaviour for what I<archive member name> is used when the C<Name> option 
-is I<not> speficied depends on the form of the C<$input> parameter:
+is I<not> specified depends on the form of the C<$input> parameter:
 
 =over 5
 


### PR DESCRIPTION

In Debian we are currently applying the following patch to
IO-Compress.
We thought you might be interested in it too.

    Description: Fix typos in POD
    Origin: vendor
    Author: gregor herrmann <gregoa@debian.org>
    Last-Update: 2019-11-04
    

The patch is tracked in our Git repository at
https://salsa.debian.org/perl-team/modules/packages/libio-compress-perl/raw/master/debian/patches/spelling.patch

Thanks for considering,
  gregor herrmann,
  Debian Perl Group
