### PR TITLE
Fix wrong START offset

### DIFF
--- a/bin/zipdetails
+++ b/bin/zipdetails
@@ -1589,9 +1589,6 @@ sub scanCentralDirectory
         my $comment_length     = unpack("v", substr($buffer, 32, 2));
         my $locHeaderOffset    = unpack("V", substr($buffer, 42, 4));
 
-        $START = $locHeaderOffset
-            if ! defined $START;
-
         skip($fh, $filename_length ) ;
 
         if ($extra_length)
@@ -1654,6 +1651,11 @@ sub scanCentralDirectory
 
     # @CD = sort { $a->[0]->cmp($b->[0]) } @CD ;
     @CD = sort { $a->[0] <=> $b->[0] } @CD ;
+
+    # Set the first LFH offset.
+    $START = $CD[0]->[0]
+        if $#CD > 0;
+
     return (1, @CD);
 }
 


### PR DESCRIPTION
Problem 1: START is set before looking up zip64 extra field. This
can lead to unproper LHF offset in case where the first entry is
located further than 0xFFFFFFFF in the archive.

Problem 2: If the order of entries in the CD does not match the
order of the LFH (e.g: The first CD entry is not the first LFH in
the archive), file scanning discard previous entries and mark them
as prefix.

Solution: Leverage @CD to generate a better START offset.