### PR TITLE
Recover from bad extra subfield

### DIFF
--- a/bin/zipdetails
+++ b/bin/zipdetails
@@ -1122,23 +1122,24 @@ sub walkExtra
 
     my $count = 0 ;
 
-    if ($XLEN < ZIP_EXTRA_SUBFIELD_ID_SIZE + ZIP_EXTRA_SUBFIELD_LEN_SIZE)
-    {
-        # Android zipalign is prime candidate for this non-standard extra field.
-        myRead($payload, $XLEN);
-        my $data = hexDump($payload);
-
-        out $payload, "Malformed Extra Data", $data;
-
-        return undef;
-    }
-
     while ($offset < $XLEN) {
 
         ++ $count;
 
-        return undef
-            if $offset + ZIP_EXTRA_SUBFIELD_HEADER_SIZE  > $XLEN ;
+        # Detect if there is not enough data for an extra ID and length.
+        # Android zipalign and zipflinger are prime candidates for this
+        # non-standard extra sub-fields.
+        my $remaining = $XLEN - $offset;
+        if ($remaining < ZIP_EXTRA_SUBFIELD_HEADER_SIZE) {
+            # There is not enough. Consum whatever is there and return so parsing
+            # can continue.
+            myRead($payload, $remaining);
+            my $data = hexDump($payload);
+
+            out $payload, "Malformed Extra Data", $data;
+
+            return undef;
+        }
 
         myRead($id, ZIP_EXTRA_SUBFIELD_ID_SIZE);
         $offset += ZIP_EXTRA_SUBFIELD_ID_SIZE;


### PR DESCRIPTION
Problem: The convention for extra field is to have an extra
subfield header (4 bytes) but some libraries don't do this.
In this case, zipdetails will fail to parse the rest of the
archive.

Solution: Detect bad extra subfield, consum whatever remains and
resume parsing.