### PR TITLE
Fix warnings once in multiple locations

### DIFF
--- a/lib/IO/Compress/Base.pm
+++ b/lib/IO/Compress/Base.pm
@@ -983,23 +983,27 @@ sub _notAvailable
     return sub { Carp::croak "$name Not Available: File opened only for output" ; } ;
 }
 
-*read     = _notAvailable('read');
-*READ     = _notAvailable('read');
-*readline = _notAvailable('readline');
-*READLINE = _notAvailable('readline');
-*getc     = _notAvailable('getc');
-*GETC     = _notAvailable('getc');
+{
+    no warnings 'once';
 
-*FILENO   = \&fileno;
-*PRINT    = \&print;
-*PRINTF   = \&printf;
-*WRITE    = \&syswrite;
-*write    = \&syswrite;
-*SEEK     = \&seek;
-*TELL     = \&tell;
-*EOF      = \&eof;
-*CLOSE    = \&close;
-*BINMODE  = \&binmode;
+    *read     = _notAvailable('read');
+    *READ     = _notAvailable('read');
+    *readline = _notAvailable('readline');
+    *READLINE = _notAvailable('readline');
+    *getc     = _notAvailable('getc');
+    *GETC     = _notAvailable('getc');
+
+    *FILENO   = \&fileno;
+    *PRINT    = \&print;
+    *PRINTF   = \&printf;
+    *WRITE    = \&syswrite;
+    *write    = \&syswrite;
+    *SEEK     = \&seek;
+    *TELL     = \&tell;
+    *EOF      = \&eof;
+    *CLOSE    = \&close;
+    *BINMODE  = \&binmode;
+}
 
 #*sysread  = \&_notAvailable;
 #*syswrite = \&_write;

--- a/lib/IO/Compress/Deflate.pm
+++ b/lib/IO/Compress/Deflate.pm
@@ -149,6 +149,7 @@ sub getExtraParams
 
 sub getInverseClass
 {
+    no warnings 'once';
     return ('IO::Uncompress::Inflate',
                 \$IO::Uncompress::Inflate::InflateError);
 }

--- a/lib/IO/Compress/Gzip.pm
+++ b/lib/IO/Compress/Gzip.pm
@@ -167,6 +167,7 @@ sub mkTrailer
 
 sub getInverseClass
 {
+    no warnings 'once';
     return ('IO::Uncompress::Gunzip',
                 \$IO::Uncompress::Gunzip::GunzipError);
 }

--- a/lib/IO/Compress/RawDeflate.pm
+++ b/lib/IO/Compress/RawDeflate.pm
@@ -135,6 +135,7 @@ sub getZlibParams
 
 sub getInverseClass
 {
+    no warnings 'once';
     return ('IO::Uncompress::RawInflate', 
                 \$IO::Uncompress::RawInflate::RawInflateError);
 }

--- a/lib/IO/Uncompress/AnyInflate.pm
+++ b/lib/IO/Uncompress/AnyInflate.pm
@@ -26,7 +26,7 @@ $AnyInflateError = '';
 
 @ISA = qw(IO::Uncompress::Base Exporter);
 @EXPORT_OK = qw( $AnyInflateError anyinflate ) ;
-%EXPORT_TAGS = %IO::Uncompress::Base::DEFLATE_CONSTANTS ;
+%EXPORT_TAGS = %IO::Uncompress::Base::DEFLATE_CONSTANTS if keys %IO::Uncompress::Base::DEFLATE_CONSTANTS;
 push @{ $EXPORT_TAGS{all} }, @EXPORT_OK ;
 Exporter::export_ok_tags('all');
 

--- a/lib/IO/Uncompress/AnyUncompress.pm
+++ b/lib/IO/Uncompress/AnyUncompress.pm
@@ -18,7 +18,7 @@ $AnyUncompressError = '';
 
 @ISA = qw(IO::Uncompress::Base Exporter);
 @EXPORT_OK = qw( $AnyUncompressError anyuncompress ) ;
-%EXPORT_TAGS = %IO::Uncompress::Base::DEFLATE_CONSTANTS ;
+%EXPORT_TAGS = %IO::Uncompress::Base::DEFLATE_CONSTANTS if keys %IO::Uncompress::Base::DEFLATE_CONSTANTS;
 push @{ $EXPORT_TAGS{all} }, @EXPORT_OK ;
 Exporter::export_ok_tags('all');
 

--- a/lib/IO/Uncompress/Base.pm
+++ b/lib/IO/Uncompress/Base.pm
@@ -1485,33 +1485,35 @@ sub input_line_number
     return $last;
 }
 
-
-*BINMODE  = \&binmode;
-*SEEK     = \&seek; 
-*READ     = \&read;
-*sysread  = \&read;
-*TELL     = \&tell;
-*EOF      = \&eof;
-
-*FILENO   = \&fileno;
-*CLOSE    = \&close;
-
 sub _notAvailable
 {
     my $name = shift ;
     return sub { croak "$name Not Available: File opened only for intput" ; } ;
 }
 
+{
+    no warnings 'once';
 
-*print    = _notAvailable('print');
-*PRINT    = _notAvailable('print');
-*printf   = _notAvailable('printf');
-*PRINTF   = _notAvailable('printf');
-*write    = _notAvailable('write');
-*WRITE    = _notAvailable('write');
+    *BINMODE  = \&binmode;
+    *SEEK     = \&seek;
+    *READ     = \&read;
+    *sysread  = \&read;
+    *TELL     = \&tell;
+    *EOF      = \&eof;
 
-#*sysread  = \&read;
-#*syswrite = \&_notAvailable;
+    *FILENO   = \&fileno;
+    *CLOSE    = \&close;
+
+    *print    = _notAvailable('print');
+    *PRINT    = _notAvailable('print');
+    *printf   = _notAvailable('printf');
+    *PRINTF   = _notAvailable('printf');
+    *write    = _notAvailable('write');
+    *WRITE    = _notAvailable('write');
+
+    #*sysread  = \&read;
+    #*syswrite = \&_notAvailable;
+}
 
 
 


### PR DESCRIPTION
Tested before/after using a oneliner
`find lib -type f |xargs -n1 perl -cw`