### PR TITLE
Generalize for EBCDIC

### DIFF
--- a/lib/IO/Uncompress/Bunzip2.pm
+++ b/lib/IO/Uncompress/Bunzip2.pm
@@ -130,7 +130,9 @@ sub chkTrailer
 sub isBzip2Magic
 {
     my $buffer = shift ;
-    return $buffer =~ /^BZh\d$/;
+
+                  # ASCII:  B   Z   h    0    9
+    return $buffer =~ qr/^\x42\x5A\x68[\x30-\x39]$/;
 }
 
 1 ;

--- a/t/105oneshot-zip-only.t
+++ b/t/105oneshot-zip-only.t
@@ -295,8 +295,16 @@ for my $stream (0, 1)
     }
 }
 
-{
+my $ebcdic_skip_msg = "Input file is in an alien character set";
+
+SKIP: {
+    skip $ebcdic_skip_msg, 3 if ord "A" != 65;
+
     title "Regression: ods streaming issue";
+
+    # To execute this test on a non-ASCII machine, we could open the zip file
+    # without using the Name parameter, or xlate the parameter to ASCII, and
+    # also xlate the contents to native.
 
     # The file before meta.xml in test.ods is content.xml.
     # Issue was triggered because content.xml was stored
@@ -323,7 +331,9 @@ for my $stream (0, 1)
 
 }
 
-{
+SKIP: {
+    skip $ebcdic_skip_msg, 3 if ord "A" != 65;
+
     title "Regression: odt non-streaming issue";
     # https://github.com/pmqs/IO-Compress/issues/13
 

--- a/t/112utf8-zip.t
+++ b/t/112utf8-zip.t
@@ -190,11 +190,13 @@ BEGIN {
     ok $u->getHeaderInfo()->{Name} eq $name, "got bad filename";
 }
 
-{
+SKIP: {
     title "unzip: EFS => 1 filename not valid utf8 - language encoding flag set";
 
+    # The name hard-coded into this pre-built file is not illegal UTF-EBCDIC
+    skip "ASCII-centric test", 1, unless ord "A" == 65;
+
     my $filename = "t/files/bad-efs.zip" ;
-    my $name = "\xF0\xA4\xAD";
 
     eval { my $u = IO::Uncompress::Unzip->new( $filename, efs => 1 )
         or die "Cannot open $filename: $UnzipError" };

--- a/t/112utf8-zip.t
+++ b/t/112utf8-zip.t
@@ -26,7 +26,7 @@ BEGIN {
     plan skip_all => "Encode is not available"
         if $@ ;
 
-    plan skip_all => "Encode not woking in perl $]"
+    plan skip_all => "Encode not working in perl $]"
         if $] >= 5.008 && $] < 5.008004 ;
 
     # use Test::NoWarnings, if available


### PR DESCRIPTION
Perl once again has been running on z/OS, for the past few Perl releases.  However not all core-shipped cpan modules pass their tests.  Each release, I knock off a few, and this year IO::Compress is one of them.

It turns out there is only one trivial change needed to the code itself to get it to work on EBCDIC boxes.  And that is the magic number for a bzip2 file is a sequence of ASCII characters.  I:C was looking for the native values for that, and failing.

The generalization commit also skips a few tests.  Two of them are because they refer to  files shipped with core that are compressed from an ASCII character set.  When uncompressed on an EBCDIC system, it won't match.  The benefit of trying to work around these seems minimal, and not worth the effort.  

The third skip is because the illegal UTF-8 sequence chosen is actually valid UTF-EBCDIC.  I looked around for sequences that would be bad in both, and there are some, but using 3 bytes instead of 4.  If you want, I could resubmit the patch using such a one, and the skip could be omitted.

I also ran this patch on the tests that normally are skipped in the core test suite because of their lengthiness.  All but one passed; it failed simply because it ran up against the CPU limits allotted to us by the providers of our free machine time on the box.

FYI, trying to open a file of the wrong compression type did not lead to a clear error message.  It took some digging for me to understand what was going on.  I suspect that it would be a common mistake for someone to do this, and they would too be in the dark as to why.