### PR TITLE
Modifying whatIs() to allow for scalar or array objects

### DIFF
--- a/lib/IO/Compress/Base/Common.pm
+++ b/lib/IO/Compress/Base/Common.pm
@@ -192,10 +192,10 @@ sub whatIs ($;$)
     return 'undef'  if ! defined $_[0] && $undef ;
 
     if (ref $_[0]) {
-        return ''       if blessed($_[0]); # is an object
         #return ''       if UNIVERSAL::isa($_[0], 'UNIVERSAL'); # is an object
         return 'buffer' if UNIVERSAL::isa($_[0], 'SCALAR');
         return 'array'  if UNIVERSAL::isa($_[0], 'ARRAY')  && $extended ;
+        return ''       if blessed($_[0]); # is an object
         return 'hash'   if UNIVERSAL::isa($_[0], 'HASH')   && $hash ;
         return 'code'   if UNIVERSAL::isa($_[0], 'CODE')   && $wantCode ;
         return '';


### PR DESCRIPTION
When using a scalar object, i.e. a blessed scalar reference, `IO::Uncompress::Gunzip::gunzip` and I suspect the other member of the `IO::Compress` family as well, rejects it with the error `illegal input parameter`.

It would be nice that it recognises those as scalar reference.

For example, consider the following code:
```perl
#!/usr/local/bin/perl
use v5.10;
use IO::Compress::Gzip;
use IO::Uncompress::Gunzip;
my $hello = 'Hello world';
my $compressed;
IO::Compress::Gzip::gzip( \$hello => \$compressed );
my $s = MyModule->new( $compressed );
my $hello;
eval
{
    IO::Uncompress::Gunzip::gunzip( $s => \$hello );
};
say $hello eq 'Hello world' ? 'ok' : 'not ok';
say $@ if( $@ );

package MyModule;
use strict;
use warnings;

sub new
{
    my $that = shift( @_ );
    my $str  = shift( @_ );
    return( bless( \$str => ( ref( $that ) || $that ) ) );
}

__END__

```

Before change, this would yield:
```
not ok
IO::Uncompress::Gunzip::gunzip: illegal input parameter
```

And after change: `ok`
