### PR TITLE
fix version checks to use correct method

### DIFF
--- a/lib/IO/Compress/Zip.pm
+++ b/lib/IO/Compress/Zip.pm
@@ -19,26 +19,26 @@ use Compress::Raw::Zlib  2.205 ();
 BEGIN
 {
     eval { require IO::Compress::Adapter::Bzip2 ;
-           IO::Compress::Adapter::Bzip2->import( 2.205 );
+           IO::Compress::Adapter::Bzip2->VERSION( 2.205 );
            require IO::Compress::Bzip2 ;
-           IO::Compress::Bzip2->import( 2.205 );
+           IO::Compress::Bzip2->VERSION( 2.205 );
          } ;
 
     eval { require IO::Compress::Adapter::Lzma ;
-           IO::Compress::Adapter::Lzma->import( 2.205 );
+           IO::Compress::Adapter::Lzma->VERSION( 2.205 );
            require IO::Compress::Lzma ;
-           IO::Compress::Lzma->import( 2.205 );
+           IO::Compress::Lzma->VERSION( 2.205 );
          } ;
 
     eval { require IO::Compress::Adapter::Xz ;
-           IO::Compress::Adapter::Xz->import( 2.205 );
+           IO::Compress::Adapter::Xz->VERSION( 2.205 );
            require IO::Compress::Xz ;
-           IO::Compress::Xz->import( 2.205 );
+           IO::Compress::Xz->VERSION( 2.205 );
          } ;
     eval { require IO::Compress::Adapter::Zstd ;
-           IO::Compress::Adapter::Zstd->import( 2.205 );
+           IO::Compress::Adapter::Zstd->VERSION( 2.205 );
            require IO::Compress::Zstd ;
-           IO::Compress::Zstd->import( 2.205 );
+           IO::Compress::Zstd->VERSION( 2.205 );
          } ;
 }
 

--- a/lib/IO/Uncompress/Unzip.pm
+++ b/lib/IO/Uncompress/Unzip.pm
@@ -24,13 +24,13 @@ BEGIN
    local $SIG{__DIE__};
 
     eval{ require IO::Uncompress::Adapter::Bunzip2 ;
-          IO::Uncompress::Adapter::Bunzip2->import(2.205) } ;
+          IO::Uncompress::Adapter::Bunzip2->VERSION(2.205) } ;
     eval{ require IO::Uncompress::Adapter::UnLzma ;
-          IO::Uncompress::Adapter::UnLzma->import(2.205) } ;
+          IO::Uncompress::Adapter::UnLzma->VERSION(2.205) } ;
     eval{ require IO::Uncompress::Adapter::UnXz ;
-          IO::Uncompress::Adapter::UnXz->import(2.205) } ;
+          IO::Uncompress::Adapter::UnXz->VERSION(2.205) } ;
     eval{ require IO::Uncompress::Adapter::UnZstd ;
-          IO::Uncompress::Adapter::UnZstd->import(2.205) } ;
+          IO::Uncompress::Adapter::UnZstd->VERSION(2.205) } ;
 }
 
 

--- a/t/006zip.t
+++ b/t/006zip.t
@@ -26,9 +26,9 @@ BEGIN {
 
     eval {
            require IO::Compress::Bzip2 ;
-           IO::Compress::Bzip2->import( 2.010 );
+           IO::Compress::Bzip2->VERSION( 2.010 );
            require IO::Uncompress::Bunzip2 ;
-           IO::Uncompress::Bunzip2->import( 2.010 );
+           IO::Uncompress::Bunzip2->VERSION( 2.010 );
          } ;
 
 }


### PR DESCRIPTION
version checks should be done with the VERSION method, not the import method. Using import would work inconsistently, because Exporter tries to handle a version being passed to import. But not all of the modules use Exporter.