### PR TITLE
IO-Compress: generalize for EBCDIC

### DIFF
--- a/t/compress/CompTestUtils.pm
+++ b/t/compress/CompTestUtils.pm
@@ -233,7 +233,7 @@ sub hexDump
         }
         print "   " x (16 - @array)
             if @array < 16 ;
-        $data =~ tr/\0-\37\177-\377/./;
+        $data =~ s/[[:^print:]]/./g;
         print "  $data\n";
     }
 


### PR DESCRIPTION
This commit changes a tr/// to a s/// and uses a regex pattern to use mnemonics instead of hard-coded code point values, so that it works on EBCDIC machines too.