### PR TITLE
Fix File::GlobMapper wildcard replacement after ordinary letters

### DIFF
--- a/lib/File/GlobMapper.pm
+++ b/lib/File/GlobMapper.pm
@@ -315,7 +315,6 @@ sub _parseOutputGlob
     }
 
     my $noPreBS = '(?<!\\\)' ; # no preceding backslash
-    my $noPreESC = '(?<![${BEGIN_DELIM}])' ; # no preceding backslash
 
     # escape any use of the delimiter symbols
     # $string =~ s/(${BEGIN_DELIM}|${END_DELIM}|${BACKSLASH_ESC})/$1$1/g;
@@ -325,7 +324,7 @@ sub _parseOutputGlob
     $string =~ s/\\\*/${STAR_ESC}/g;
 
     # Transform "#3" to BEGIN_DELIM 3 END_DELIM
-    $string =~ s/${noPreESC}#(\d)/${BEGIN_DELIM}${1}${END_DELIM}/g;
+    $string =~ s/#(\d)/${BEGIN_DELIM}${1}${END_DELIM}/g;
 
     $string =~ s#\*#${BEGIN_DELIM}${END_DELIM}#g;
 
@@ -351,20 +350,18 @@ sub _getFiles
         my $outFile = $inFile ;
         my @matches ;
 
-        my $noPreESC = '(?<![${BEGIN_DELIM}])' ; # no preceding backslash
-
         if (@matches = ($inFile =~ m/$self->{InputPattern}/ ))
         {
             $outFile = $self->{OutputPattern};
             my $ix = 1;
 
             # get the filename glob
-            $outFile =~ s/${noPreESC}${BEGIN_DELIM}${END_DELIM}/$inFile/g;
+            $outFile =~ s/${BEGIN_DELIM}${END_DELIM}/$inFile/g;
 
             # now each of the #1, #2,...
             for my $pattern (@matches)
             {
-                $outFile =~ s/${noPreESC}${BEGIN_DELIM}${ix}${END_DELIM}/$pattern/g;
+                $outFile =~ s/${BEGIN_DELIM}${ix}${END_DELIM}/$pattern/g;
 
                 ++ $ix;
             }

--- a/t/globmapper.t
+++ b/t/globmapper.t
@@ -24,7 +24,7 @@ Perl $]" )
     $extra = 1
         if eval { require Test::NoWarnings ;  Test::NoWarnings->import; 1 };
 
-    plan tests => 76 + $extra ;
+    plan tests => 80 + $extra ;
 
     use_ok('File::GlobMapper') ;
 }
@@ -337,6 +337,24 @@ Perl $]" )
         [ [map { "$tmpDir/$_" } ("abc1.tmp", "X-c1-#1*-X")],
           [map { "$tmpDir/$_" } ("abc2.tmp", "X-c2-#1*-X")],
           [map { "$tmpDir/$_" } ("abc3.tmp", "X-c3-#1*-X")],
+        ], "  got mapping";
+}
+
+{
+    title "check wildcard references after ordinary letters";
+
+    my $tmpDir ;#= 'td';
+    my $lex = LexDir->new( $tmpDir );
+
+    touch map { "$tmpDir/$_.tmp" } qw( abc ) ;
+
+    my $map = File::GlobMapper::globmap("$tmpDir/a*.tmp", "$tmpDir/B#1.out");
+    ok $map, "  got map"
+        or diag $File::GlobMapper::Error ;
+
+    is @{ $map }, 1, "  returned 1 map";
+    is_deeply $map,
+        [ [map { "$tmpDir/$_" } ("abc.tmp", "Bbc.out")],
         ], "  got mapping";
 }
 


### PR DESCRIPTION
The eval-removal change used a single-quoted negative lookbehind containing ${BEGIN_DELIM}. That made the regex treat the characters in the literal string "${BEGIN_DELIM}" as excluded preceding characters, so output patterns such as B#1.out or IMG#1.out did not expand #1.

Escaped literal # and * are already protected with HASH_ESC and STAR_ESC before wildcard references are converted to internal markers, so the lookbehind is not needed. Replace exact internal marker sequences directly when generating output filenames.

Add a regression test for expanding #1 after an ordinary letter.