### PR TITLE
remove dead backwards compatibility code

### DIFF
--- a/Makefile.PL
+++ b/Makefile.PL
@@ -14,6 +14,10 @@ use ExtUtils::MakeMaker 5.16 ;
 UpDowngrade(getPerlFiles('MANIFEST'))
     unless $ENV{PERL_CORE};
 
+# Old ExtUtils::MakeMakers may have literal _ in their VERSIONs. Strip it out
+# so we can use normal numeric comparisons: '6.57_02' -> 6.5702
+(my $mm_version = ExtUtils::MakeMaker->VERSION) =~ tr/_//d;
+
 WriteMakefile(
     NAME         => 'IO::Compress',
     VERSION_FROM => 'lib/IO/Compress/Base.pm',
@@ -54,7 +58,7 @@ WriteMakefile(
         : ()
     ),
 
-     ( eval { ExtUtils::MakeMaker->VERSION(6.46) }
+     ( $mm_version >= 6.46
         ? ( META_MERGE  => {
 
                 "meta-spec" => { version => 2 },
@@ -82,7 +86,7 @@ WriteMakefile(
         : ()
     ),
 
-    ((ExtUtils::MakeMaker->VERSION() gt '6.30') ?
+    ($mm_version >= 6.30 ?
         ('LICENSE'  => 'perl')         : ()),
 
 ) ;

--- a/Makefile.PL
+++ b/Makefile.PL
@@ -35,18 +35,12 @@ WriteMakefile(
 		                    'Scalar::Util'  => 0,
                             'Encode'        => 0,
                             'Time::Local'   => 0,
-		                    $] >= 5.005 && $] < 5.006
-                                ? ('File::BSDGlob' => 0)
-                                : () }
+                          }
 	      )
     ),
 
-    (
-    $] >= 5.005
-        ? (ABSTRACT => 'IO Interface to compressed data files/buffers',
-            AUTHOR  => 'Paul Marquess <pmqs@cpan.org>')
-        : ()
-    ),
+    ABSTRACT => 'IO Interface to compressed data files/buffers',
+    AUTHOR   => 'Paul Marquess <pmqs@cpan.org>',
 
     INSTALLDIRS => ($] >= 5.009 && $] < 5.011 ? 'perl' : 'site'),
 

--- a/lib/File/GlobMapper.pm
+++ b/lib/File/GlobMapper.pm
@@ -3,25 +3,7 @@ package File::GlobMapper;
 use strict;
 use warnings;
 use Carp;
-
-our ($CSH_GLOB);
-
-BEGIN
-{
-    if ($] < 5.006)
-    {
-        require File::BSDGlob; File::BSDGlob->import(':glob');
-        $CSH_GLOB = File::BSDGlob::GLOB_CSH();
-        *globber = \&File::BSDGlob::csh_glob;
-    }
-    else
-    {
-        require File::Glob; File::Glob->import(':glob');
-        $CSH_GLOB = File::Glob::GLOB_CSH();
-        #*globber = \&File::Glob::bsd_glob;
-        *globber = \&File::Glob::csh_glob;
-    }
-}
+use File::Glob ':glob';
 
 our ($Error);
 
@@ -67,7 +49,7 @@ sub new
     my $inputGlob = shift ;
     my $outputGlob = shift ;
     # TODO -- flags needs to default to whatever File::Glob does
-    my $flags = shift || $CSH_GLOB ;
+    my $flags = shift || GLOB_CSH;
     #my $flags = shift ;
 
     $inputGlob =~ s/^\s*\<\s*//;
@@ -94,7 +76,7 @@ sub new
     $self->_parseOutputGlob()
         or return undef ;
 
-    my @inputFiles = globber($self->{InputGlob}, $flags) ;
+    my @inputFiles = File::Glob::csh_glob($self->{InputGlob}, $flags) ;
 
     if (GLOB_ERROR)
     {

--- a/lib/IO/Compress/Base.pm
+++ b/lib/IO/Compress/Base.pm
@@ -1,8 +1,6 @@
 
 package IO::Compress::Base ;
 
-require 5.006 ;
-
 use strict ;
 use warnings;
 

--- a/lib/IO/Compress/Base/Common.pm
+++ b/lib/IO/Compress/Base/Common.pm
@@ -445,7 +445,7 @@ sub createSelfTiedObject
     my $error_ref = shift ;
 
     my $obj = bless Symbol::gensym(), ref($class) || $class;
-    tie *$obj, $obj if $] >= 5.005;
+    tie *$obj, $obj;
     *$obj->{Closed} = 1 ;
     $$error_ref = '';
     *$obj->{Error} = $error_ref ;

--- a/lib/IO/Compress/Base/Common.pm
+++ b/lib/IO/Compress/Base/Common.pm
@@ -89,9 +89,7 @@ sub getEncoding($$$)
 }
 
 our ($needBinmode);
-$needBinmode = ($^O eq 'MSWin32' ||
-                    ($] >= 5.006 && eval ' ${^UNICODE} || ${^UTF8LOCALE} '))
-                    ? 1 : 1 ;
+$needBinmode = 1;
 
 sub setBinModeInput($)
 {

--- a/lib/IO/Compress/Deflate.pm
+++ b/lib/IO/Compress/Deflate.pm
@@ -1,7 +1,5 @@
 package IO::Compress::Deflate ;
 
-require 5.006 ;
-
 use strict ;
 use warnings;
 use bytes;

--- a/lib/IO/Compress/Gzip.pm
+++ b/lib/IO/Compress/Gzip.pm
@@ -1,7 +1,5 @@
 package IO::Compress::Gzip ;
 
-require 5.006 ;
-
 use strict ;
 use warnings;
 use bytes;

--- a/lib/IO/Compress/Zlib/Extra.pm
+++ b/lib/IO/Compress/Zlib/Extra.pm
@@ -1,7 +1,5 @@
 package IO::Compress::Zlib::Extra;
 
-require 5.006 ;
-
 use strict ;
 use warnings;
 use bytes;

--- a/lib/IO/Uncompress/Gunzip.pm
+++ b/lib/IO/Uncompress/Gunzip.pm
@@ -1,8 +1,5 @@
 
 package IO::Uncompress::Gunzip ;
-
-require 5.006 ;
-
 # for RFC1952
 
 use strict ;

--- a/lib/IO/Uncompress/Unzip.pm
+++ b/lib/IO/Uncompress/Unzip.pm
@@ -1,7 +1,4 @@
 package IO::Uncompress::Unzip;
-
-require 5.006 ;
-
 # for RFC1952
 
 use strict ;

--- a/t/010examples-bzip2.t
+++ b/t/010examples-bzip2.t
@@ -17,9 +17,6 @@ use IO::Compress::Bzip2 'bzip2' ;
 
 BEGIN
 {
-    plan(skip_all => "Examples needs Perl 5.005 or better - you have Perl $]" )
-        if $] < 5.005 ;
-
     # use Test::NoWarnings, if available
     my $extra = 0 ;
     $extra = 1

--- a/t/010examples-zlib.t
+++ b/t/010examples-zlib.t
@@ -17,9 +17,6 @@ use IO::Compress::Gzip 'gzip' ;
 
 BEGIN
 {
-    plan(skip_all => "Examples needs Perl 5.005 or better - you have Perl $]" )
-        if $] < 5.005 ;
-
     # use Test::NoWarnings, if available
     my $extra = 0 ;
     $extra = 1

--- a/t/011-streamzip.t
+++ b/t/011-streamzip.t
@@ -17,9 +17,6 @@ use IO::Uncompress::Unzip 'unzip' ;
 
 BEGIN
 {
-    plan(skip_all => "Needs Perl 5.005 or better - you have Perl $]" )
-        if $] < 5.005 ;
-
     # use Test::NoWarnings, if available
     my $extra = 0 ;
     $extra = 1

--- a/t/105oneshot-gzip-only.t
+++ b/t/105oneshot-gzip-only.t
@@ -14,10 +14,6 @@ use Test::More ;
 use CompTestUtils;
 
 BEGIN {
-    plan(skip_all => "oneshot needs Perl 5.005 or better - you have Perl $]" )
-        if $] < 5.005 ;
-
-
     # use Test::NoWarnings, if available
     my $extra = 0 ;
     $extra = 1

--- a/t/105oneshot-zip-bzip2-only.t
+++ b/t/105oneshot-zip-bzip2-only.t
@@ -14,9 +14,6 @@ use Test::More ;
 use CompTestUtils;
 
 BEGIN {
-    plan(skip_all => "oneshot needs Perl 5.005 or better - you have Perl $]" )
-        if $] < 5.005 ;
-
     plan(skip_all => "IO::Compress::Bzip2 not available" )
         unless eval { require IO::Compress::Bzip2;
                       require IO::Uncompress::Bunzip2;

--- a/t/105oneshot-zip-only.t
+++ b/t/105oneshot-zip-only.t
@@ -15,10 +15,6 @@ use File::Spec ;
 use CompTestUtils;
 
 BEGIN {
-    plan(skip_all => "oneshot needs Perl 5.005 or better - you have Perl $]" )
-        if $] < 5.005 ;
-
-
     # use Test::NoWarnings, if available
     my $extra = 0 ;
     $extra = 1

--- a/t/105oneshot-zip-store-only.t
+++ b/t/105oneshot-zip-store-only.t
@@ -14,9 +14,6 @@ use Test::More ;
 use CompTestUtils;
 
 BEGIN {
-    plan(skip_all => "oneshot needs Perl 5.005 or better - you have Perl $]" )
-        if $] < 5.005 ;
-
     plan skip_all => "Lengthy Tests Disabled\n" .
                      "set COMPRESS_ZLIB_RUN_ALL or COMPRESS_ZLIB_RUN_MOST to run this test suite"
         unless defined $ENV{COMPRESS_ZLIB_RUN_ALL} or defined $ENV{COMPRESS_ZLIB_RUN_MOST};

--- a/t/112utf8-zip.t
+++ b/t/112utf8-zip.t
@@ -18,9 +18,6 @@ use IO::Compress::Zip     qw($ZipError);
 use IO::Uncompress::Unzip qw($UnzipError);
 
 BEGIN {
-    plan skip_all => "Encode is not available"
-        if $] < 5.006 ;
-
     eval { require Encode; Encode->import(); };
 
     plan skip_all => "Encode is not available"

--- a/t/113issues.t
+++ b/t/113issues.t
@@ -18,9 +18,6 @@ use IO::Compress::Zip     qw($ZipError);
 use IO::Uncompress::Unzip qw($UnzipError);
 
 BEGIN {
-    plan skip_all => "Encode is not available"
-        if $] < 5.006 ;
-
     eval { require Encode; Encode->import(); };
 
     plan skip_all => "Encode is not available"

--- a/t/compress/destroy.pl
+++ b/t/compress/destroy.pl
@@ -10,7 +10,7 @@ use CompTestUtils;
 BEGIN
 {
     plan(skip_all => "Destroy not supported in Perl $]")
-        if $] == 5.008 || ( $] >= 5.005 && $] < 5.006) ;
+        if $] == 5.008;
 
     # use Test::NoWarnings, if available
     my $extra = 0 ;

--- a/t/compress/encode.pl
+++ b/t/compress/encode.pl
@@ -8,9 +8,6 @@ use CompTestUtils;
 
 BEGIN
 {
-    plan skip_all => "Encode is not available"
-        if $] < 5.006 ;
-
     eval { require Encode; Encode->import(); };
 
     plan skip_all => "Encode is not available"

--- a/t/compress/generic.pl
+++ b/t/compress/generic.pl
@@ -611,10 +611,7 @@ EOM
             my $foo = "1234567890";
 
             is $io->syswrite($foo, length($foo)), length($foo), "  syswrite ok" ;
-            if ( $] < 5.6 )
-              { is $io->syswrite($foo, length $foo), length $foo, "  syswrite ok" }
-            else
-              { is $io->syswrite($foo), length $foo, "  syswrite ok" }
+            is $io->syswrite($foo), length $foo, "  syswrite ok";
             is $io->syswrite($foo, length($foo)), length $foo, "  syswrite ok";
             is $io->write($foo, length($foo), 5), 5,   " write 5";
             is $io->write("xxx\n", 100, -1), 1, "  write 1";

--- a/t/compress/newtied.pl
+++ b/t/compress/newtied.pl
@@ -10,9 +10,6 @@ our ($BadPerl, $UncompressClass);
 
 BEGIN
 {
-    plan(skip_all => "Extra Tied Filehandle needs Perl 5.6 or better - you have Perl $]" )
-        if $] < 5.006 ;
-
     my $tests ;
 
     $BadPerl = ($] >= 5.006 and $] <= 5.008) ;

--- a/t/compress/newtied.pl
+++ b/t/compress/newtied.pl
@@ -103,10 +103,7 @@ sub run
             my $foo = "1234567890";
 
             ok syswrite($io, $foo, length($foo)) == length($foo) ;
-            if ( $] < 5.6 )
-              { is $io->syswrite($foo, length $foo), length $foo }
-            else
-              { is $io->syswrite($foo), length $foo }
+            is $io->syswrite($foo), length $foo;
             ok $io->syswrite($foo, length($foo)) == length $foo;
             ok $io->write($foo, length($foo), 5) == 5;
             ok $io->write("xxx\n", 100, -1) == 1;

--- a/t/compress/oneshot.pl
+++ b/t/compress/oneshot.pl
@@ -7,10 +7,6 @@ use Test::More ;
 use CompTestUtils;
 
 BEGIN {
-    plan(skip_all => "oneshot needs Perl 5.005 or better - you have Perl $]" )
-        if $] < 5.005 ;
-
-
     # use Test::NoWarnings, if available
     my $extra = 0 ;
     $extra = 1

--- a/t/compress/oneshot.pl
+++ b/t/compress/oneshot.pl
@@ -115,7 +115,7 @@ sub run
             # Threaded 5.6.x seems to have a problem comparing filehandles.
             use Config;
 
-            skip 'Cannot compare filehandles with threaded $]', 2
+            skip "Cannot compare filehandles with threaded $]", 2
                 if $] >= 5.006  && $] < 5.007 && $Config{useithreads};
 
             my $lex = LexFile->new( my $out_file );

--- a/t/compress/tied.pl
+++ b/t/compress/tied.pl
@@ -11,9 +11,6 @@ our ($BadPerl, $UncompressClass);
 
 BEGIN
 {
-    plan(skip_all => "Tied Filehandle needs Perl 5.005 or better" )
-        if $] < 5.005 ;
-
     # use Test::NoWarnings, if available
     my $extra = 0 ;
     $extra = 1

--- a/t/compress/tied.pl
+++ b/t/compress/tied.pl
@@ -150,10 +150,7 @@ sub run
             my $foo = "1234567890";
 
             ok syswrite($io, $foo, length($foo)) == length($foo) ;
-            if ( $] < 5.6 )
-              { is $io->syswrite($foo, length $foo), length $foo }
-            else
-              { is $io->syswrite($foo), length $foo }
+            is $io->syswrite($foo), length $foo;
             ok $io->syswrite($foo, length($foo)) == length $foo;
             ok $io->write($foo, length($foo), 5) == 5;
             ok $io->write("xxx\n", 100, -1) == 1;

--- a/t/cz-03zlib-v1.t
+++ b/t/cz-03zlib-v1.t
@@ -23,16 +23,7 @@ BEGIN
     $extra = 1
         if eval { require Test::NoWarnings ;  Test::NoWarnings->import; 1 };
 
-    my $count = 0 ;
-    if ($] < 5.005) {
-        $count = 453 ;
-    }
-    else {
-        $count = 471 ;
-    }
-
-
-    plan tests => $count + $extra ;
+    plan tests => 471 + $extra ;
 
     use_ok('Compress::Zlib', qw(:ALL memGunzip memGzip zlib_version));
     use_ok('IO::Compress::Gzip::Constants') ;
@@ -847,7 +838,6 @@ EOM
 
 }
 
-if ($] >= 5.005)
 {
     # test inflate with a substr
 
@@ -876,7 +866,6 @@ if ($] >= 5.005)
 
 }
 
-if ($] >= 5.005)
 {
     # deflate/inflate in scalar context
 

--- a/t/cz-05examples.t
+++ b/t/cz-05examples.t
@@ -17,9 +17,6 @@ use Compress::Zlib;
 
 BEGIN
 {
-    plan(skip_all => "Examples needs Perl 5.005 or better - you have Perl $]" )
-        if $] < 5.005 ;
-
     # use Test::NoWarnings, if available
     my $extra = 0 ;
     $extra = 1

--- a/t/cz-08encoding.t
+++ b/t/cz-08encoding.t
@@ -15,9 +15,6 @@ use CompTestUtils;
 
 BEGIN
 {
-    plan skip_all => "Encode is not available"
-        if $] < 5.006 ;
-
     eval { require Encode; Encode->import(); };
 
     plan skip_all => "Encode is not available"

--- a/t/globmapper.t
+++ b/t/globmapper.t
@@ -15,10 +15,6 @@ use CompTestUtils;
 
 BEGIN
 {
-    plan(skip_all => "File::GlobMapper needs Perl 5.005 or better - you have
-Perl $]" )
-        if $] < 5.005 ;
-
     # use Test::NoWarnings, if available
     my $extra = 0 ;
     $extra = 1


### PR DESCRIPTION
Most of this patch is dead code removal. If a file uses `use warnings`, which is a compile-time error on perls before v5.6.0, any subsequent runtime tests such as `if ($] < 5.006)` or `require 5.006` are redundant: A perl that would fail these checks wouldn't have made it this far into the file anyway.

Plus a few bug fixes:
- use numeric comparison operators for comparing version numbers, not string operators (because `10.0` lt `5.99`)
-  use double quotes to interpolate `$]` in skip message; don't print it literally
- `$] < 5.6` should have been `$] < 5.006`